### PR TITLE
improve the parsing of concepts in text

### DIFF
--- a/app/components/chart/index.tsx
+++ b/app/components/chart/index.tsx
@@ -123,7 +123,7 @@ const Chart = ({config, loadedCallback}) => {
                             ...dimensionSingleValues,
                             ...val,
                             y: val["value"],
-                            x: Date.UTC(val[xAxisConcept].split('-')[0], (val[xAxisConcept].split('-').length > 1 ? val[xAxisConcept][1]: 1), (val[xAxisConcept].split('-').length > 2 ? val[xAxisConcept].split('-')[2]: 1)) 
+                            x: Date.UTC(val[xAxisConcept].split('-')[0], (val[xAxisConcept].split('-').length > 1 ? val[xAxisConcept].split('-')[1]: 1), (val[xAxisConcept].split('-').length > 2 ? val[xAxisConcept].split('-')[2]: 1))
                             };
                         });
                         seriesData.push({


### PR DESCRIPTION
`{$CONCEPT}` and `{CONCEPT}` parsing handled.
improve parsing of concept for `TIME_PERIOD` when multiple values returns a text like "start_value - end_value"
enclosed a yaml for testing:
```yaml
---
DashID: COVID
Rows:
-
    Row: 0
    chartType: TITLE
    Title: "COVID-19 Dashboard"
    Subtitle: 
    Unit: 
    unitLoc: 
    Decimals: 
    LabelsYN:
    legendConcept: 
    legendLoc: 
    xAxisConcept: 
    yAxisConcept: 
    downloadYN: 
    dataLink: 
    metadataLink: 
    DATA: 
-
    Row: 1 
    chartType: LINES, double
    Title: "Number of COVID-19 cases"
    Subtitle: "{$TIME_PERIOD}" 
    Unit: 
    unitLoc: 
    Decimals: 0
    LabelsYN: No
    legendConcept: GEO_PICT
    legendLoc: BOTTOM
    xAxisConcept: TIME_PERIOD
    yAxisConcept: OBS_VALUE
    downloadYN: 
    dataLink: 
    metadataLink: 
    DATA: "https://stats-sdmx-disseminate.pacificdata.org/rest/data/SPC,DF_COVID,1.0/M..CASES?lastNObservations=13&dimensionAtObservation=AllDimensions"
-
    Row: 2 
    chartType: LINES, double
    Title: "Number of COVID-19 deaths"
    Subtitle: "{$TIME_PERIOD}" 
    Unit: 
    unitLoc: 
    Decimals: 0
    LabelsYN: No
    legendConcept: GEO_PICT
    legendLoc: BOTTOM
    xAxisConcept: TIME_PERIOD
    yAxisConcept: OBS_VALUE
    downloadYN: 
    dataLink: 
    metadataLink: 
    DATA: "https://stats-sdmx-disseminate.pacificdata.org/rest/data/SPC,DF_COVID,1.0/M..DEATHS?lastNObservations=13&dimensionAtObservation=AllDimensions"
```