### PR TITLE
update to match new sdmx-json-parser version

### DIFF
--- a/app/components/chart/index.tsx
+++ b/app/components/chart/index.tsx
@@ -111,7 +111,7 @@ const Chart = ({config} : {config: any}) => {
                         data.forEach((dataItem: any, index: number, data: [any]) => {
                             data[index].value = eval(`${data[index].value} ${dataObj.operator} ${operandValue}`);
                         });
-                        return [data, parser.getRawDimensions()];
+                        return [data, parser.getDimensions()];
                     } else {
                         // operand is another SDMX request
                         const parserOperand = new SDMXParser();
@@ -125,11 +125,11 @@ const Chart = ({config} : {config: any}) => {
                             data.forEach((dataItem: any, index: number, data: [any]) => {
                                 data[index].value = eval(`${data[index].value} ${dataObj.operator} ${operandValue}`);
                             });
-                            return [data, parser.getRawDimensions()];
+                            return [data, parser.getDimensions()];
                         });
                     }
                 } else {
-                    return [data, parser.getRawDimensions()];
+                    return [data, parser.getDimensions()];
                 }
             })
         });

--- a/app/components/map/index.tsx
+++ b/app/components/map/index.tsx
@@ -221,7 +221,7 @@ const MapComponent = ({config} : {config: any}) => {
         })
     }).then(() => {
       const data = sdmxParser.getData();
-      const dimensions = sdmxParser.getRawDimensions();
+      const dimensions = sdmxParser.getDimensions();
       const attributes = sdmxParser.getAttributes();
       initialMap.on('pointermove', (evt: MapBrowserEvent<UIEvent>) => {
         if (evt.dragging) {

--- a/app/components/value/index.tsx
+++ b/app/components/value/index.tsx
@@ -42,7 +42,7 @@ const Value = ({ config }: {config: any}) => {
             })
         }).then(() => {
             const data = sdmxParser.getData();
-            const dimensions = sdmxParser.getRawDimensions();
+            const dimensions = sdmxParser.getDimensions();
             const attributes = sdmxParser.getAttributes();
 
             const titleObj = parseTextExpr(config.Title, dimensions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-dom": "18.2.0",
         "react-dropzone": "^14.2.3",
         "react-error-boundary": "^4.0.11",
-        "sdmx-json-parser": "^0.2.0-beta.3",
+        "sdmx-json-parser": "^0.3.0-beta.0",
         "typescript": "5.1.6"
       },
       "devDependencies": {
@@ -3659,9 +3659,9 @@
       }
     },
     "node_modules/sdmx-json-parser": {
-      "version": "0.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/sdmx-json-parser/-/sdmx-json-parser-0.2.0-beta.3.tgz",
-      "integrity": "sha512-FlUY5KJhIYkQOVd5PYYb6isfenM0hRLFg3vsS5Dg6vyY7japjgCz9hvvB2i+rrbiMYwBP5UgHQs/Xx39/4eDsg==",
+      "version": "0.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/sdmx-json-parser/-/sdmx-json-parser-0.3.0-beta.0.tgz",
+      "integrity": "sha512-9hIRx5awECz5sftbOlR8197kfjWOQPFbRe5/eDfhMTDBNFry3nQG+DDC8aYrzXGc2vjs6eXc+sHbJSK8vWWzng==",
       "dependencies": {
         "@streamparser/json": "^0.0.15"
       }
@@ -9611,9 +9611,9 @@
       }
     },
     "sdmx-json-parser": {
-      "version": "0.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/sdmx-json-parser/-/sdmx-json-parser-0.2.0-beta.3.tgz",
-      "integrity": "sha512-FlUY5KJhIYkQOVd5PYYb6isfenM0hRLFg3vsS5Dg6vyY7japjgCz9hvvB2i+rrbiMYwBP5UgHQs/Xx39/4eDsg==",
+      "version": "0.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/sdmx-json-parser/-/sdmx-json-parser-0.3.0-beta.0.tgz",
+      "integrity": "sha512-9hIRx5awECz5sftbOlR8197kfjWOQPFbRe5/eDfhMTDBNFry3nQG+DDC8aYrzXGc2vjs6eXc+sHbJSK8vWWzng==",
       "requires": {
         "@streamparser/json": "^0.0.15"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.3",
     "react-error-boundary": "^4.0.11",
-    "sdmx-json-parser": "^0.2.0-beta.3",
+    "sdmx-json-parser": "^0.3.0-beta.0",
     "typescript": "5.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
New sdmx-json-parser version (0.3.0-beta.0) better handles now the retrieving of SDMX concepts.
It also has been refactored to simplify the API.
`getRawDimensions` has been renamed to `getDimensions`.